### PR TITLE
Harden pre-create container cleanup to avoid stale-name restart race

### DIFF
--- a/templates/systemd/hubsite.service.j2
+++ b/templates/systemd/hubsite.service.j2
@@ -21,7 +21,7 @@ DefaultDependencies=no
 Type=simple
 Environment="HOME={{ devture_systemd_docker_base_systemd_unit_home_path }}"
 
-ExecStartPre={{ devture_systemd_docker_base_host_command_sh }} -c 'i=0; while [ "$i" -lt 10 ]; do {{ devture_systemd_docker_base_host_command_docker }} rm -f {{ hubsite_identifier }} >/dev/null 2>&1 || true; if ! {{ devture_systemd_docker_base_host_command_docker }} inspect {{ hubsite_identifier }} >/dev/null 2>&1; then exit 0; fi; i=$((i + 1)); sleep 1; done; echo "Failed to remove stale container {{ hubsite_identifier }}" >&2; exit 1'
+ExecStartPre={{ devture_systemd_docker_base_host_command_sh }} -c 'i=0; while [ "$i" -lt 10 ]; do {{ devture_systemd_docker_base_host_command_docker }} rm -f {{ hubsite_identifier }} >/dev/null 2>&1 || true; if ! {{ devture_systemd_docker_base_host_command_docker }} inspect --type=container {{ hubsite_identifier }} >/dev/null 2>&1; then exit 0; fi; i=$((i + 1)); sleep 1; done; echo "Failed to remove stale container {{ hubsite_identifier }}" >&2; exit 1'
 
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
       --rm \

--- a/templates/systemd/hubsite.service.j2
+++ b/templates/systemd/hubsite.service.j2
@@ -21,18 +21,17 @@ DefaultDependencies=no
 Type=simple
 Environment="HOME={{ devture_systemd_docker_base_systemd_unit_home_path }}"
 
-ExecStartPre=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} stop -t {{ devture_systemd_docker_base_container_stop_grace_time_seconds }} {{ hubsite_identifier }} 2>/dev/null || true'
-ExecStartPre=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} rm {{ hubsite_identifier }} 2>/dev/null || true'
+ExecStartPre={{ devture_systemd_docker_base_host_command_sh }} -c 'i=0; while [ "$i" -lt 10 ]; do {{ devture_systemd_docker_base_host_command_docker }} rm -f {{ hubsite_identifier }} >/dev/null 2>&1 || true; if ! {{ devture_systemd_docker_base_host_command_docker }} inspect {{ hubsite_identifier }} >/dev/null 2>&1; then exit 0; fi; i=$((i + 1)); sleep 1; done; echo "Failed to remove stale container {{ hubsite_identifier }}" >&2; exit 1'
 
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
       --rm \
       --name={{ hubsite_identifier }} \
       --log-driver=none \
       --cap-drop=ALL \
-      --cap-add=CHOWN \
       --cap-add=NET_BIND_SERVICE \
       --cap-add=SETGID \
       --cap-add=SETUID \
+      --cap-add=CHOWN \
       --network={{ hubsite_container_network }} \
       {% if hubsite_container_http_host_bind_port %}
       -p {{ hubsite_container_http_host_bind_port }}:{{ hubsite_container_http_port }} \


### PR DESCRIPTION
Problem
- During all-at-once restarts, Docker can briefly keep a removed container name reserved, causing `docker create --name ...` to fail with `Conflict. The container name ... is already in use`.
- The previous pre-create cleanup was best-effort and could leave a short race window.

Evidence
- Example incident on 2026-02-28:
  - `09:00:39` `docker create` failed for `mash-collabora-online` with name-conflict.
  - `09:00:41` `docker create` failed for `mash-neko` with name-conflict.
- Both units auto-recovered afterwards, indicating a startup race rather than persistent crash.

Fix
- Replace one-shot pre-create cleanup with bounded deterministic cleanup in `ExecStartPre`:
  - run `docker rm -f` in a short loop,
  - verify absence via `docker inspect --type=container`,
  - fail explicitly after timeout with a clear error.
- Keep `ExecStop` behavior unchanged.

Why 10 seconds
- Targets transient removal lag while keeping restart behavior bounded.
- Prefers deterministic fail-fast over silent flake or unbounded waiting.

Intentional reliability choice
- This intentionally fails explicitly if cleanup does not complete within the bound, replacing silent best-effort cleanup that could hide flakes.

Compatibility
- No variable/API changes.
- Normal successful startup path is unchanged.

Validation
- `pre-commit run --all-files` (where configured)
- `ansible-lint .`
- Runtime restart-cycle verification on MASH host for this failure class.

Changed file
- `templates/systemd/hubsite.service.j2`
